### PR TITLE
add checkboxes to search results to choose which results to download to csv

### DIFF
--- a/data_management/templates/search.html
+++ b/data_management/templates/search.html
@@ -26,13 +26,22 @@
     </form>
 
     {% if link_id %}
+    <form method="post" action="{% url 'csv_output_selected' link_id %}">
+      {% csrf_token %}
       <div class="csv"> 
-        <a href="{% url 'csv_output' link_id %}"> Click to Download CSV</a>
+        <button type="submit"> Click to Download CSV</button>
+        <!-- <a href="{% url 'csv_output' link_id %}"> Click to Download CSV</a> -->
       </div>
-
+    
       <table style="width:100%">
       {% for process_info in output %}
         {% for column_name, value in process_info.items %}
+          {% if forloop.first %} <!-- Checkbox in the first row of each table -->
+            <tr>
+              <td rowspan="{{ process_info.items|length }}">
+                <input type="checkbox" name="selected_items" value="{{ forloop.parentloop.counter0 }}">
+              </td>
+          {% endif %}
           {% if column_name == "picture" %}
             <tr>
               <th> {{ column_name }} </th>
@@ -50,7 +59,8 @@
           {% endif %}
         {% endfor %}
       {% endfor %}
-    </table>
+      </table>
+    </form>
     {% endif %}
     
     {% if used_process %}

--- a/webapps/urls.py
+++ b/webapps/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('search', views.search_page, name="search"),
     path('chip', views.chip_page, name="chip"),
     path('csv_output/<int:csv_id>/$', views.csv_output, name='csv_output'),
+    path('csv_output_selected/<int:csv_id>/$', views.csv_output_selected, name='csv_output_selected'),
     path('photo/<slug:process>/<int:chip_id>', views.get_photo, name='photo'),
     path('central', views.central_action, name='central'),
     path('chipnum/<int:chip_id>', views.display_chip, name='chipnum'),


### PR DESCRIPTION
users can now download a specific selection (instead of all) of the results returned from our search feature.
this update also fixes the issue where the headers were printed twice in the csv output.